### PR TITLE
Fix edge case with self referencing models

### DIFF
--- a/drf_nested_resource/utils.py
+++ b/drf_nested_resource/utils.py
@@ -199,7 +199,7 @@ def find_parent_to_child_manager(parent_obj, child_model):
         if isinstance(rel, GenericRel):
             return issubclass(rel.to, child_model)
         if isinstance(rel, RelatedObject):
-            if issubclass(rel.model, child_model):
+            if isinstance(parent_obj, rel.parent_model) and issubclass(rel.model, child_model):
                 return True
             # reverse
             if issubclass(rel.parent_model, child_model):
@@ -221,12 +221,21 @@ def find_parent_to_child_manager(parent_obj, child_model):
             child_model._meta.get_all_related_many_to_many_objects(),
         )
     )
-    if len(set(related_objects)) != 1:
+    if len(set(related_objects)) < 1:
         raise ImproperlyConfigured(
             "Unable to find manager from {!r} to {!r}.  You may need to declare "
             "`parent_to_child_manager_attr` on your view if the manager is in a "
             "custom location.".format(
                 parent_obj.__class__, child_model,
+            )
+        )
+    elif len(set(related_objects)) > 1:
+        raise ImproperlyConfigured(
+            "Found multiple valid related objects while trying to find manager "
+            "from {!r} to {!r}.  You may need to declare "
+            "`parent_to_child_manager_attr` on your view.  Found related objects "
+            "{!r}".format(
+                parent_obj.__class__, child_model, related_objects,
             )
         )
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -54,3 +54,10 @@ class SelfReferencingManyToManyModel(models.Model):
 
     class Meta(ShortenPermissionsNameMeta):
         pass
+
+
+class ManyToManyTowardsSelfReference(models.Model):
+    targets = models.ManyToManyField(SelfReferencingManyToManyModel)
+
+    class Meta(ShortenPermissionsNameMeta):
+        pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,7 @@ from tests.models import (
     ManyToManySourceModel,
     ManyToManySourceNoRelatedNameModel,
     SelfReferencingManyToManyModel,
+    ManyToManyTowardsSelfReference,
 )
 
 
@@ -264,6 +265,14 @@ class GetParentToChildManagerTest(TestCase):
 
     def test_many_to_many_relationship_with_self(self):
         parent_obj = SelfReferencingManyToManyModel.objects.create()
+        manager = find_parent_to_child_manager(
+            parent_obj=parent_obj,
+            child_model=SelfReferencingManyToManyModel,
+        )
+        self.assertManagersEqual(manager, parent_obj.targets)
+
+    def test_m2m_towards_self_referencing_model(self):
+        parent_obj = ManyToManyTowardsSelfReference.objects.create()
         manager = find_parent_to_child_manager(
             parent_obj=parent_obj,
             child_model=SelfReferencingManyToManyModel,


### PR DESCRIPTION
### What is the problem / feature ?

In the case where you are targeting a `ManyToManyField` towards a model that has a self referencing `ManyToManyField` the `find_parent_to_child_manager` utility function was failing because it would incorrectly find both relations.
### How did it get fixed / implemented ?

Added an extra condition to exclude self referencing relations unless they are of the correct types for the parent and child models in question.
### How can someone test / see it ?

Tests?

_Here is a cute animal picture for your troubles..._

![maxresdefault 1](https://cloud.githubusercontent.com/assets/824194/4634808/cb33e6bc-53d3-11e4-9670-3085242764b9.jpg)
