### PR TITLE
Include assets in source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include HISTORY.rst
 include LICENSE
 include README.rst
 recursive-include drf_nested_resource *.html *.png *.gif *js *.css *jpg *jpeg *svg *py
+recursive-include docs Makefile *.rst *.py *.bat

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include LICENSE
 include README.rst
 recursive-include drf_nested_resource *.html *.png *.gif *js *.css *jpg *jpeg *svg *py
 recursive-include docs Makefile *.rst *.py *.bat
+recursive-include tests *.py


### PR DESCRIPTION
It would be nice to have documentation sources and tests included in the source tarball that gets uploaded to PyPI so others can rebuilt and verify the whole project. I would also need this for the Debian package which builds the documentation from source and runs the tests during build.
